### PR TITLE
Fix: Pass namespace to dialer

### DIFF
--- a/pkg/forward/forwarder.go
+++ b/pkg/forward/forwarder.go
@@ -71,7 +71,7 @@ func (f *Forwarder) dialer() (httpstream.Dialer, error) {
 		return nil, err
 	}
 
-	return spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", f.Client.RESTClient().Post().Prefix("api/v1").Resource("pods").Namespace("default").Name(f.pod).SubResource("portforward").URL()), nil
+	return spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", f.Client.RESTClient().Post().Prefix("api/v1").Resource("pods").Namespace(f.Namespace).Name(f.pod).SubResource("portforward").URL()), nil
 }
 
 func (f *Forwarder) createPod(ctx context.Context, spec Spec) error {


### PR DESCRIPTION
Ensure pod namespace is passed when creating the portforward request. Was playing around in different namespaces, and found that the namespace flag is hardcoded to "default" when setting up the port forward call, which results in a not found error

```
$ go run . -n not-default host port
Error: error upgrading connection: pods "port-forward-remote-qfkz8" not found
```