### PR TITLE
Feat: Delete pod on sigterm

### DIFF
--- a/pkg/forward/forwarder.go
+++ b/pkg/forward/forwarder.go
@@ -3,6 +3,7 @@ package forward
 import (
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"os/signal"
@@ -55,8 +56,7 @@ func (f *Forwarder) Forward(ctx context.Context, spec Spec) error {
 		<-ch.Done()
 
 		if err := f.deletePod(ctx); err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			log.Fatal(err)
 		}
 
 		os.Exit(0)


### PR DESCRIPTION
This is my first time playing with channels so there's a good chance there's a better way to handle this. Not really happy with exiting from the goroutine, as this is an arbitrary place to be exiting the program from. Suggestions welcome!

When the user exits the process with a sigterm, the CLI does not call the deferred deletePod method, resulting in the pods being left in the cluster. The addition listens for a sigterm, calls deletePod and exits. 